### PR TITLE
fix: ensure thumbnails and screenshots directories exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,9 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 screenshot.png
+
+# Thumbnails 
+thumbnails/*
+
+# Screenshots
+screenshots/*

--- a/agents.py
+++ b/agents.py
@@ -73,13 +73,14 @@ def customize_analysis_depth(depth):
     else:
         return "Conduct a standard analysis covering all key areas."
 
-def analyze_website(website_url, analysis_depth="standard"):
+def analyze_website(website_url, analysis_depth="standard", initial_analysis=""):
     depth_instruction = customize_analysis_depth(analysis_depth)
     
     try:
         user_proxy.initiate_chat(
             manager,
             message=f"Evaluate the design of the website: {website_url}. {depth_instruction}\n"
+                    f"Consider this initial analysis based on visual and textual elements:\n{initial_analysis}\n\n"
                     f"Coordinate these evaluations:\n"
                     f"1. Design Analysis\n"
                     f"2. Usability Report\n"

--- a/main.py
+++ b/main.py
@@ -6,8 +6,8 @@ import os
 def evaluate_website_design(website_url, analysis_depth):
     initial_analysis, thumbnail_path = analyze_website(website_url)
     
-    # Use the new analyze_website function from agents.py
-    results = agents.analyze_website(website_url, analysis_depth)
+    # Pass the initial_analysis to the agents
+    results = agents.analyze_website(website_url, analysis_depth, initial_analysis)
     
     if "error" in results:
         return (

--- a/website_analyzer.py
+++ b/website_analyzer.py
@@ -15,6 +15,10 @@ def analyze_website(url):
     if not url.startswith(('http://', 'https://')):
         url = 'https://' + url
 
+    # Ensure the thumbnail and screenshot directories exist
+    os.makedirs('thumbnails', exist_ok=True)
+    os.makedirs('screenshots', exist_ok=True)
+
     response = requests.get(url)
     soup = BeautifulSoup(response.content, 'html.parser')
     text = soup.get_text(separator=' ', strip=True)


### PR DESCRIPTION
The absence of the thumbnails folder was causing the process to fail. This commit:

- Adds directory creation for both 'thumbnails' and 'screenshots' at the start of the analyze_website function
- Uses os.makedirs() with exist_ok=True to safely create directories
- Add thumbnails and screenshots folders to .gitignore

This change guarantees the necessary directories exist before any operations that require them, resolving the runtime failure.